### PR TITLE
Fixes consent verification for existing user onboarding workflow

### DIFF
--- a/version2/LifeSpace/CardinalKit/Components/Onboarding/CKReviewConsentDocument.swift
+++ b/version2/LifeSpace/CardinalKit/Components/Onboarding/CKReviewConsentDocument.swift
@@ -11,45 +11,53 @@ import Firebase
 import ResearchKit
 
 
-public class CKReviewConsentDocument: ORKQuestionStep{
+public class CKReviewConsentDocument: ORKQuestionStep {
+    
+    // Boolean step that checks for the existence of a consent document
+    // and sets its answer to the result. Used for navigation during
+    // onboarding.
+    
     public override init(
         identifier: String
     ) {
         super.init(identifier: identifier)
         self.answerFormat = ORKAnswerFormat.booleanAnswerFormat()
     }
-
+    
     @available(*, unavailable)
     public required init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 }
 
-public class CKReviewConsentDocumentViewController:ORKQuestionStepViewController{
-    public var CKReviewConsentDocument: CKReviewConsentDocument!{
+public class CKReviewConsentDocumentViewController:ORKQuestionStepViewController {
+    public var CKReviewConsentDocument: CKReviewConsentDocument! {
         return step as? CKReviewConsentDocument
     }
     
     public override func viewDidLoad() {
         let storage = Storage.storage()
         let storageRef = storage.reference()
-        // REVIEW IF DOCUMENT EXIST
+        
+        // Attempt to download consent document from cloud storage
         if let DocumentCollection = CKStudyUser.shared.consentCollection {
             let config = CKPropertyReader(file: "CKConfiguration")
             let consentFileName = config.read(query: "Consent File Name")
             let DocumentRef = storageRef.child("\(DocumentCollection)\(consentFileName).pdf")
-            // Create local filesystem URL
+            
             var docURL = (FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)).last as NSURL?
             docURL = docURL?.appendingPathComponent("\(consentFileName).pdf") as NSURL?
             let url = docURL! as URL
-            // Download to the local filesystem
-            let downloadTask = DocumentRef.write(toFile: url) { url, error in
-              if let error = error {
-                  print("Consent Error: " + error.localizedDescription)
-                  self.setAnswer(false)
-              } else {
-                  self.setAnswer(true)
-              }
+            
+            DocumentRef.write(toFile: url) { url, error in
+                if let error = error {
+                    // Couldn't download consent document
+                    print("Error downloading consent document: " + error.localizedDescription)
+                    self.setAnswer(false)
+                } else {
+                    // Successfully downloaded consent document
+                    self.setAnswer(true)
+                }
                 super.goForward()
             }
         }

--- a/version2/LifeSpace/CardinalKit/Components/Onboarding/CKReviewConsentDocument.swift
+++ b/version2/LifeSpace/CardinalKit/Components/Onboarding/CKReviewConsentDocument.swift
@@ -45,7 +45,7 @@ public class CKReviewConsentDocumentViewController:ORKQuestionStepViewController
             // Download to the local filesystem
             let downloadTask = DocumentRef.write(toFile: url) { url, error in
               if let error = error {
-                  print(error.localizedDescription)
+                  print("Consent Error: " + error.localizedDescription)
                   self.setAnswer(false)
               } else {
                   self.setAnswer(true)

--- a/version2/LifeSpace/CardinalKit/Components/Onboarding/OnboardingViewController+Coordinator.swift
+++ b/version2/LifeSpace/CardinalKit/Components/Onboarding/OnboardingViewController+Coordinator.swift
@@ -236,6 +236,8 @@ class OnboardingViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
         case is CKSignInWithAppleStep:
             // handle Sign in with Apple
             return CKSignInWithAppleStepViewController(step: step)
+        case is CKReviewConsentDocument:
+            return CKReviewConsentDocumentViewController(step: step)
         default:
             return nil
         }


### PR DESCRIPTION
The existing user onboarding workflow was not correctly verifying whether the user has previously signed a consent form and requiring all existing users to resign consent. This pull request corrects the ResearchKit navigation logic.