### PR TITLE
Fixes login issue #19

### DIFF
--- a/version2/LifeSpace/CardinalKit/Components/LaunchUIView.swift
+++ b/version2/LifeSpace/CardinalKit/Components/LaunchUIView.swift
@@ -16,11 +16,12 @@ struct LaunchUIView: View {
     
     @State var didCompleteOnboarding = false
     @ObservedObject var launchData: LaunchModel = LaunchModel.sharedinstance
+    @ObservedObject var studyUser: CKStudyUser  = CKStudyUser.shared
 
     var body: some View {
         VStack(spacing: 10) {
             
-            if didCompleteOnboarding && (CKStudyUser.shared.currentUser != nil){
+            if didCompleteOnboarding && (studyUser.currentUser != nil) {
                 if launchData.showSurvey {
                     DailySurveyStartButton()
                 } else if launchData.showPermissionView {
@@ -29,7 +30,7 @@ struct LaunchUIView: View {
                     MainUIView()
                 }
             } else {
-                OnboardingUIView() {
+                OnboardingUIView {
                     //on complete
                     if let completed = UserDefaults.standard.object(forKey: Constants.onboardingDidComplete) as? Bool {
                        self.didCompleteOnboarding = completed

--- a/version2/LifeSpace/CardinalKit/Components/MainUIView.swift
+++ b/version2/LifeSpace/CardinalKit/Components/MainUIView.swift
@@ -15,7 +15,6 @@ struct MainUIView: View {
     
     init() {
         self.color = Color(config.readColor(query: "Primary Color"))
-        
     }
     
     var body: some View {

--- a/version2/LifeSpace/CardinalKit/Library/Auth/CKStudyUser.swift
+++ b/version2/LifeSpace/CardinalKit/Library/Auth/CKStudyUser.swift
@@ -9,18 +9,14 @@ import Foundation
 import Firebase
 import CardinalKit
 
-class CKStudyUser {
+class CKStudyUser: ObservableObject {
 
     static let shared = CKStudyUser()
     
     /* **************************************************************
      * the current user only resolves if we are logged in
      **************************************************************/
-    var currentUser: User? {
-        // this is a reference to the
-        // Firebase + Google Identity User
-        return Auth.auth().currentUser
-    }
+    var currentUser: User?
 
     /* **************************************************************
      * store your Firebase objects under this path in order to

--- a/version2/LifeSpace/CardinalKit/Library/Auth/CKStudyUser.swift
+++ b/version2/LifeSpace/CardinalKit/Library/Auth/CKStudyUser.swift
@@ -16,7 +16,7 @@ class CKStudyUser: ObservableObject {
     /* **************************************************************
      * the current user only resolves if we are logged in
      **************************************************************/
-    var currentUser: User?
+    @Published var currentUser: User?
 
     /* **************************************************************
      * store your Firebase objects under this path in order to

--- a/version2/LifeSpace/CardinalKit/SceneDelegate.swift
+++ b/version2/LifeSpace/CardinalKit/SceneDelegate.swift
@@ -13,6 +13,8 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
+    weak var handle: AuthStateDidChangeListenerHandle?
+
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -27,6 +29,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             window.rootViewController = UIHostingController(rootView: contentView)
             self.window = window
             window.makeKeyAndVisible()
+        }
+
+        // Set up auth state listener
+        handle = Auth.auth().addStateDidChangeListener { (auth, user) in
+            if(user != nil) {
+                CKStudyUser.shared.currentUser = user
+            } else {
+                CKStudyUser.shared.currentUser = nil
+            }
         }
     }
     


### PR DESCRIPTION
This PR addresses login issue #19 by implementing an auth state listener that updates CKStudyUser's currentUser property when the authentication state changes. Also, CKStudyUser now conforms to ObservableObject and currentUser is now a published property, so that SwiftUI views depending on it will refresh when the auth state changes.

@annabelxtan @PSchmiedmayer