### PR TITLE
Enable firebase offline persistence

### DIFF
--- a/version2/LifeSpace/CardinalKit/Components/LocationService.swift
+++ b/version2/LifeSpace/CardinalKit/Components/LocationService.swift
@@ -27,12 +27,7 @@ class LocationService: NSObject, CLLocationManagerDelegate {
                 // Append latest location to the map and then save it to the database
                 if AlternovaLocationFetcher.shared.appendNewLocationPoint(point: lastKnownLocation) {
                     if let mapPointsCollection = CKStudyUser.shared.mapPointsCollection {
-                        let settings = FirestoreSettings()
-                        settings.isPersistenceEnabled = false
-
                         let db = Firestore.firestore()
-                        db.settings = settings
-
                         db.collection(mapPointsCollection)
                             .document(UUID().uuidString)
                             .setData([
@@ -50,7 +45,7 @@ class LocationService: NSObject, CLLocationManagerDelegate {
             }
         }
     }
-
+    
     override init() {
         super.init()
         manager.delegate = self

--- a/version2/LifeSpace/CardinalKit/Library/Auth/CKStudyUser.swift
+++ b/version2/LifeSpace/CardinalKit/Library/Auth/CKStudyUser.swift
@@ -11,6 +11,8 @@ import CardinalKit
 
 class CKStudyUser: ObservableObject {
 
+    let db = Firestore.firestore()
+
     static let shared = CKStudyUser()
     
     /* **************************************************************
@@ -52,7 +54,7 @@ class CKStudyUser: ObservableObject {
         }
         return nil
     }
-    
+
     var surveysCollection: String? {
         if let baseCollection = baseCollection {
             return "\(baseCollection)/\(prefix)_surveys/"
@@ -64,7 +66,7 @@ class CKStudyUser: ObservableObject {
         if let authCollection = authCollection {
             return "\(authCollection)\(prefix)_consent/"
         }
-        
+
         return nil
     }
 
@@ -138,10 +140,7 @@ class CKStudyUser: ObservableObject {
 
             CKSession.shared.userId = uid
             CKSendHelper.createNecessaryDocuments(path: dataBucket)
-            let settings = FirestoreSettings()
-            settings.isPersistenceEnabled = false
-            let db = Firestore.firestore()
-            db.settings = settings
+
             db.collection(dataBucket).document(uid).setData([
                 "userID": uid,
                 "studyID": studyID ?? "",
@@ -165,7 +164,7 @@ class CKStudyUser: ObservableObject {
         // Update in database
         if let dataBucket = rootAuthCollection,
            let uid = currentUser?.uid {
-            let db = Firestore.firestore()
+
             db.collection(dataBucket).document(uid).updateData([
                 "lastSurveyDate": today])
         }
@@ -178,7 +177,6 @@ class CKStudyUser: ObservableObject {
         if let dataBucket = rootAuthCollection,
            let uid = currentUser?.uid {
 
-            let db = Firestore.firestore()
             let document = try await db.collection(dataBucket).document(uid).getDocument()
             let lastSurveyDateString = document.get("lastSurveyDate") as? String
             UserDefaults.standard.setValue(lastSurveyDateString, forKey: Constants.lastSurveyDate)

--- a/version2/LifeSpace/CardinalKit/Library/Networking/CKNetworkManager.swift
+++ b/version2/LifeSpace/CardinalKit/Library/Networking/CKNetworkManager.swift
@@ -72,11 +72,8 @@ class CKAppNetworkManager: CKAPIDeliveryDelegate, CKAPIReceiverDelegate {
             }
     }
     
-    private func firestoreDb()->Firestore{
-        let settings = FirestoreSettings()
-        settings.isPersistenceEnabled = false
+    private func firestoreDb() -> Firestore {
         let db = Firestore.firestore()
-        db.settings = settings
         return db
     }
 //    func downloadSurveys(){
@@ -97,11 +94,11 @@ class CKAppNetworkManager: CKAPIDeliveryDelegate, CKAPIReceiverDelegate {
 ////            }
 ////        }
 //    }
-    
+
 }
 
 extension CKAppNetworkManager {
-    
+
     /**
      Send HealthKit data using Firebase
     */
@@ -113,13 +110,13 @@ extension CKAppNetworkManager {
                 onCompletion(false)
                 return
             }
-            
+
             let identifier = Date().startOfDay.shortStringFromDate() + "-\(package.fileName)"
             let trimmedIdentifier = identifier.trimmingCharacters(in: .whitespaces)
-            
+
             let db=firestoreDb()
             db.collection(authPath + "\(Constants.dataBucketHealthKit)").document(trimmedIdentifier).setData(json) { err in
-                
+
                 if let err = err {
                     onCompletion(false)
                     print("Error writing document: \(err)")
@@ -128,34 +125,33 @@ extension CKAppNetworkManager {
                     print("[sendHealthKit] \(trimmedIdentifier) - successfully written!")
                 }
             }
-            
+
         } catch {
             print("Error \(error.localizedDescription)")
             onCompletion(false)
             return
         }
     }
-    
+
     /**
      Send Sensor data using Cloud Storage
     */
     fileprivate func sendSensorData(_ file: URL, _ package: Package, _ onCompletion: @escaping (Bool) -> Void) {
-        
         guard let stanfordRITBucket = CKStudyUser.shared.authCollection else { return }
-        
+
         let storageRef = Storage.storage().reference()
         let ref = storageRef.child("\(stanfordRITBucket)\(Constants.dataBucketStorage)/coremotion/\(package.fileName)/\(file.lastPathComponent)")
-        
+
         let uploadTask = ref.putFile(from: file, metadata: nil)
-        uploadTask.observe(.success) { snapshot in
+        uploadTask.observe(.success) { _ in
             print("[sendSensorData] file uploaded successfully!")
         }
-        
+
         uploadTask.observe(.failure) { snapshot in
             print("[sendSensorData] error uploading file!")
         }
     }
-    
+
     fileprivate func sendMetricsData(_ file: URL, _ package: Package, _ onCompletion: @escaping (Bool) -> Void) {
         do {
             let data = try Data(contentsOf: file)
@@ -164,9 +160,9 @@ extension CKAppNetworkManager {
                 onCompletion(false)
                 return
             }
-            
+
             let identifier:String = (json["date"] as? String ?? Date().shortStringFromDate())+"Activity_index"
-            
+
             let db=firestoreDb()
             db.collection(authPath + "\(Constants.dataBucketMetrics)").document(identifier).setData(json) { err in
                 
@@ -178,12 +174,12 @@ extension CKAppNetworkManager {
                     print("[sendMetrics] \(identifier) - successfully written!")
                 }
             }
-            
+
         } catch {
             print("Error \(error.localizedDescription)")
             onCompletion(false)
             return
         }
     }
-    
+
 }

--- a/version2/LifeSpace/CardinalKit/Library/Networking/CKSendHelper.swift
+++ b/version2/LifeSpace/CardinalKit/Library/Networking/CKSendHelper.swift
@@ -10,11 +10,8 @@ import Foundation
 import Firebase
 
 class CKSendHelper {
-    private static func firestoreDb() -> Firestore{
-        let settings = FirestoreSettings()
-        settings.isPersistenceEnabled = false
+    private static func firestoreDb() -> Firestore {
         let db = Firestore.firestore()
-        db.settings = settings
         return db
     }
     /**


### PR DESCRIPTION
Allows location data to be cached locally if network is down and synchronized with firebase when network comes back up.