### PR TITLE
Makes map question skippable

### DIFF
--- a/version2/LifeSpace/CardinalKit/Components/Survey/MapQuestionStep.swift
+++ b/version2/LifeSpace/CardinalKit/Components/Survey/MapQuestionStep.swift
@@ -56,11 +56,20 @@ public class MapQuestionStepViewController: ORKQuestionStepViewController {
         noButton.addTarget(self, action: #selector(OnClickNoButton), for: .touchUpInside)
         self.view.addSubview(noButton)
 
+        let skipButton = UIButton(frame: CGRect(x: 0, y: 555, width: 350, height: 50))
+        skipButton.center.x = view.center.x
+        skipButton.setTitle("Skip", for: .normal)
+        skipButton.setTitleColor(.systemBlue, for: .normal)
+        skipButton.layer.cornerRadius = 10
+        skipButton.backgroundColor = .white
+        skipButton.addTarget(self, action: #selector(OnClickSkipButton), for: .touchUpInside)
+        self.view.addSubview(skipButton)
+
         self.view.backgroundColor = .white
         MapboxMap.initializeMap(mapView: mapView, reload: false)
     }
     
-    @objc func OnClickYesButton(){
+    @objc func OnClickYesButton() {
       self.setAnswer(true)
       super.goForward()
     }
@@ -68,5 +77,9 @@ public class MapQuestionStepViewController: ORKQuestionStepViewController {
     @objc func OnClickNoButton() {
         self.setAnswer(false)
         super.goForward()
+    }
+
+    @objc func OnClickSkipButton() {
+        super.skipForward()
     }
 }

--- a/version2/LifeSpace/CardinalKit/Components/Survey/MapQuestionStep.swift
+++ b/version2/LifeSpace/CardinalKit/Components/Survey/MapQuestionStep.swift
@@ -33,20 +33,23 @@ public class MapQuestionStepViewController: ORKQuestionStepViewController {
         QuestionLabel.textAlignment = NSTextAlignment.center
         self.view.addSubview(QuestionLabel)
 
+        // Map of today's points
         mapView = MapView(frame: CGRect(x: 0, y: 120, width: 400, height: 400))
         mapView.center.x = view.center.x
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         self.view.addSubview(mapView)
-        
-        let button = UIButton(frame: CGRect(x: 0, y: 450, width: 350, height: 50))
-        button.center.x = view.center.x
-        button.setTitle("Yes", for: .normal)
-        button.setTitleColor(.white, for: .normal)
-        button.layer.cornerRadius = 10
-        button.backgroundColor = .systemBlue
-        button.addTarget(self, action: #selector(OnClickYesButton), for: .touchUpInside)
-        self.view.addSubview(button)
-        
+
+        // "Yes" button
+        let yesButton = UIButton(frame: CGRect(x: 0, y: 450, width: 350, height: 50))
+        yesButton.center.x = view.center.x
+        yesButton.setTitle("Yes", for: .normal)
+        yesButton.setTitleColor(.white, for: .normal)
+        yesButton.layer.cornerRadius = 10
+        yesButton.backgroundColor = .systemBlue
+        yesButton.addTarget(self, action: #selector(OnClickYesButton), for: .touchUpInside)
+        self.view.addSubview(yesButton)
+
+        // "No" button
         let noButton = UIButton(frame: CGRect(x: 0, y: 505, width: 350, height: 50))
         noButton.center.x = view.center.x
         noButton.setTitle("No", for: .normal)
@@ -56,6 +59,7 @@ public class MapQuestionStepViewController: ORKQuestionStepViewController {
         noButton.addTarget(self, action: #selector(OnClickNoButton), for: .touchUpInside)
         self.view.addSubview(noButton)
 
+        // "Skip" button
         let skipButton = UIButton(frame: CGRect(x: 0, y: 555, width: 350, height: 50))
         skipButton.center.x = view.center.x
         skipButton.setTitle("Skip", for: .normal)

--- a/version2/LifeSpace/CardinalKit/Library/ResearchKit/CKUploadToGCPTaskViewControllerDelegate.swift
+++ b/version2/LifeSpace/CardinalKit/Library/ResearchKit/CKUploadToGCPTaskViewControllerDelegate.swift
@@ -37,12 +37,16 @@ class CKUploadToGCPTaskViewControllerDelegate: NSObject, ORKTaskViewControllerDe
 
                 // Extract results from each question:
 
+                let SKIP_VALUE = -1 // value that represents a skipped question
+
                 // Question 1 - How would you rate your day?
                 if let dayRatingQuestionStepResult = taskViewController.result.stepResult(forStepIdentifier: "DayRatingQuestionStep")?.results {
                     let answer = dayRatingQuestionStepResult[0] as? ORKScaleQuestionResult
                     let result = answer?.scaleAnswer
                     resultData["dayRatingScale"] = result
                     isSurveyEmpty = false
+                } else {
+                    resultData["dayRatingScale"] = SKIP_VALUE
                 }
 
                 // Question 2 - How would generally rate your enjoyment of the physical environments in which you spent time today?
@@ -51,14 +55,18 @@ class CKUploadToGCPTaskViewControllerDelegate: NSObject, ORKTaskViewControllerDe
                     let result = answer?.scaleAnswer
                     resultData["environmentScale"] = result
                     isSurveyEmpty = false
+                } else {
+                    resultData["environmentScale"] = SKIP_VALUE
                 }
 
                 // Question 3 - Is this map of your daily activity accurate?
                 if let mapAccuracyBooleanQuestionResult = taskViewController.result.stepResult(forStepIdentifier: "MapAccuracyBooleanQuestionStep")?.results {
                     let answer = mapAccuracyBooleanQuestionResult[0] as? ORKBooleanQuestionResult
                     let result = answer?.booleanAnswer
-                    resultData["isMapAccurate"] = result
+                    resultData["isMapAccurate"] = Int(truncating: result ?? SKIP_VALUE as NSNumber)
                     isSurveyEmpty = false
+                } else {
+                    resultData["isMapAccurate"] = SKIP_VALUE
                 }
 
                 // Question 4 - Please explain why not (please do not disclose any health information)
@@ -70,7 +78,7 @@ class CKUploadToGCPTaskViewControllerDelegate: NSObject, ORKTaskViewControllerDe
                 }
 
                 // If the survey is empty at this point, do not try to save it.
-                if (isSurveyEmpty) { return }
+                if isSurveyEmpty { return }
 
                 // Write the extracted results to firebase
                 if let surveysCollection = CKStudyUser.shared.surveysCollection {

--- a/version2/LifeSpace/CardinalKit/Supporting Files/Constants.swift
+++ b/version2/LifeSpace/CardinalKit/Supporting Files/Constants.swift
@@ -33,7 +33,7 @@ class Constants {
     static let JHFirstLocationRequest = "JHFirstLocationRequest"
     
     static let lastSurveyDate = "LAST_SURVEY_DATE"
-    static let hourToOpenSurvey = 12 // Hour to open survey daily in military time
+    static let hourToOpenSurvey = 19 // Hour to open survey daily in military time
 
     static let minDistanceBetweenPoints = 100.0 // minimum distance between location points to record
 

--- a/version2/LifeSpace/CardinalKit/Supporting Files/Constants.swift
+++ b/version2/LifeSpace/CardinalKit/Supporting Files/Constants.swift
@@ -33,7 +33,7 @@ class Constants {
     static let JHFirstLocationRequest = "JHFirstLocationRequest"
     
     static let lastSurveyDate = "LAST_SURVEY_DATE"
-    static let hourToOpenSurvey = 19 // Hour to open survey daily in military time
+    static let hourToOpenSurvey = 12 // Hour to open survey daily in military time
 
     static let minDistanceBetweenPoints = 100.0 // minimum distance between location points to record
 


### PR DESCRIPTION
All questions in the survey should be skippable. This PR adds a missing skip button to the map question. It also prevents an empty survey from being saved to the DB. In addition, it keeps track of which questions were skipped by coding them with a -1.