### PR TITLE
Fixes issue with keyboard safe area covering fields

### DIFF
--- a/version2/LifeSpace/CardinalKit/Components/HomeView.swift
+++ b/version2/LifeSpace/CardinalKit/Components/HomeView.swift
@@ -68,6 +68,8 @@ struct HomeView: View {
                             }
                             .sheet(isPresented: $showingSurvey) {
                                 CKTaskViewController(tasks: DailySurveyTask(showInstructions: false))
+                                    .ignoresSafeArea(.container, edges: .bottom)
+                                    .ignoresSafeArea(.keyboard, edges: .bottom)
                             }
                         }.groupBoxStyle(ButtonGroupBoxStyle())
 


### PR DESCRIPTION
Users noted that the keyboard safe area covered text fields in surveys. This PR corrects this issue.