### PR TITLE
Add passcode instruction step

### DIFF
--- a/version2/LifeSpace/CardinalKit/Supporting Files/CKConfiguration.plist
+++ b/version2/LifeSpace/CardinalKit/Supporting Files/CKConfiguration.plist
@@ -25,7 +25,7 @@
 	<key>Consent File Name</key>
 	<string>consent</string>
 	<key>Passcode Text</key>
-	<string>Now you will create a passcode to identify yourself to the app and protect access to information you&apos;ve entered.</string>
+	<string>Now you will create a passcode to identify yourself to the app and protect access to information you&apos;ve entered. This is different from your Study ID.</string>
 	<key>Passcode Type</key>
 	<string>4</string>
 	<key>Completion Step Title</key>


### PR DESCRIPTION
Updates the onboarding flow to include an instruction step prior to passcode selection that clarifies to the user the purpose of the passcode and differentiates the passcode from the study ID.