### PR TITLE
Updates build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       run:
         working-directory: version2/LifeSpace
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: latest-stable
@@ -23,12 +23,12 @@ jobs:
       run: |
           xcodebuild -version
           swift --version
-    - name: Set Mapbox Credentials
-      run: |
-        echo "machine api.mapbox.com" >> ~/.netrc
-        echo "login mapbox" >> ~/.netrc
-        echo "password ${{ secrets.MAPBOX_TOKEN }}" >> ~/.netrc
-        chmod 0600 ~/.netrc
+    - name: Set Mapbox credentials
+      uses: extractions/netrc@v1
+      with:
+        machine: api.mapbox.com
+        username: mapbox
+        password: ${{ secrets.MAPBOX_TOKEN }}
     - name: Install Dependencies
       run: |
         gem install cocoapods


### PR DESCRIPTION
The current build action fails when installing dependencies from Cocoapods. This is likely due to the inability to properly set the `.netrc` file on the runner with the Mapbox token in order to download the iOS library from their private registry. This PR updates the action to set the `.netrc` properly.