### PR TITLE
Update README with link to new repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 <img src="https://user-images.githubusercontent.com/1212163/167851008-e5398f1d-18ac-49e7-a24d-1529b891b965.jpg" width="300" />
 
-<br />
+> [!NOTE]
+> This repository contains an earlier version of the LifeSpace app. The app has since been redesigned and rebuilt using the [Stanford Spezi](https://github.com/StanfordSpezi) framework. You can find the latest version here: https://github.com/StanfordBDHG/LifeSpace.
 
-To evaluate how environmental conditions influence health, we have developed a novel measure of the space within which individuals live and move. We will create individual life-space maps, based on a custom smartphone application that uses Global Positioning System (GPS)-based methods. By mapping the space within which individuals live and move, we can study features of the social and built environment that support health, and identify opportunities for intervention to protect disadvantaged communities. [Odden Research Lab](https://michelleodden.com/)
+To evaluate how environmental conditions influence health, we have developed a novel measure of the space within which individuals live and move. We will create individual life-space maps, based on a custom smartphone application that uses Global Positioning System (GPS)-based methods. By mapping the space within which individuals live and move, we can study features of the social and built environment that support health, and identify opportunities for intervention to protect disadvantaged communities. Learn more at the [Odden Research Lab](https://michelleodden.com/) website.
 
 ## Built with
 - [CardinalKit](https://cardinalkit.org/)
@@ -13,6 +14,9 @@ To evaluate how environmental conditions influence health, we have developed a n
 ## Installation
 Please refer to [installation guide](INSTALL.md) for installation instructions.
 
-## Lead Developers
-- Annabel Tan (annabelxtan@stanford.edu)
-- Vishnu Ravi (vishnur@stanford.edu)
+## Contributors
+
+- [Vishnu Ravi, MD](https://github.com/vishnuravi)
+- [Annabel Tan, MPH](https://github.com/annabelxtan)
+- [Sylvie Dobrota Lai, MS](https://github.com/sylvieddl)
+- [Michelle Odden, PhD](https://michelleodden.com/)


### PR DESCRIPTION
The LifeSpace project has been redesigned and rebuilt using the [Stanford Spezi](https://github.com/StanfordSpezi) framework. This update to the README adds a note about this and provides a link to the new repository: https://github.com/StanfordBDHG/LifeSpace. The earlier version will be archived in this repository.